### PR TITLE
'at-import-partial-extension' has been deprecated; use 'load-partial-extension' instead

### DIFF
--- a/packages/stylelint-config-scss/src/index.ts
+++ b/packages/stylelint-config-scss/src/index.ts
@@ -17,7 +17,7 @@ const config: Config = {
         'scss/load-no-partial-leading-underscore': [
             true,
         ],
-        'scss/at-import-partial-extension': [
+        'scss/load-partial-extension': [
             'never',
         ],
         'scss/at-rule-no-unknown': [


### PR DESCRIPTION
Deprecation warnings:
 - The "scss/at-import-partial-extension" rule is deprecated.
 - 'at-import-partial-extension has been deprecated, and will be removed in '7.0'. Use 'load-partial-extension' instead. See: https://github.com/stylelint-scss/stylelint-scss/blob/v6.4.1/src/rules/at-import-partial-extension/README.md